### PR TITLE
Potential fix for code scanning alert no. 1: Bad redirect check

### DIFF
--- a/path.go
+++ b/path.go
@@ -39,7 +39,7 @@ func cleanPath(p string) string {
 	r := 1
 	w := 1
 
-	if p[0] != '/' {
+	if p[0] != '/' || (n > 1 && (p[1] == '/' || p[1] == '\\')) {
 		r = 0
 
 		if n+1 > stackBufSize {


### PR DESCRIPTION
Potential fix for [https://github.com/PHPDevsr/gin-forked/security/code-scanning/1](https://github.com/PHPDevsr/gin-forked/security/code-scanning/1)

To fix the issue, the `cleanPath` function in `path.go` should be updated to include a check for URLs starting with `//` or `/\`. This can be achieved by adding a condition to verify that the second character of the path is not `/` or `\` when the first character is `/`. If the path fails this check, it should be sanitized to a safe default value (e.g., `/`).

The changes will be made in the `cleanPath` function in `path.go`. No changes are required in `gin.go` since the vulnerability originates from the `cleanPath` function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
